### PR TITLE
fix: KeyError on optional values

### DIFF
--- a/custom_components/multiroom-mqtt-mediaplayer/media_player.py
+++ b/custom_components/multiroom-mqtt-mediaplayer/media_player.py
@@ -427,9 +427,9 @@ class MQTTMediaPlayer(MediaPlayerEntity):
             MULTIROOM_MASTER: config.get(MULTIROOM_MASTER_TEMPLATE),
         }
         self._payload = {
-             "POWER_OFF": config[PAYLOAD_POWEROFFSTATUS],
-             "PLAYER_PLAYING": config[PAYLOAD_PLAYERSTATUS],
-             "MULTIROOM_MASTER": config[PAYLOAD_MULTIROOM_MASTER]
+             "POWER_OFF": config.get(PAYLOAD_POWEROFFSTATUS),
+             "PLAYER_PLAYING": config.get(PAYLOAD_PLAYERSTATUS),
+             "MULTIROOM_MASTER": config.get(PAYLOAD_MULTIROOM_MASTER)
         }
 
         for key, tpl in list(self._templates.items()):


### PR DESCRIPTION
Fixing the KeyError when not having set the optional keys in config
```  File "/config/custom_components/multiroom-mqtt-mediaplayer/media_player.py", line 430, in _setup_from_config
    "POWER_OFF": config[PAYLOAD_POWEROFFSTATUS],
KeyError: 'payload_poweroff'```